### PR TITLE
Correct android status bar height on android pre-lollipop

### DIFF
--- a/styles.js
+++ b/styles.js
@@ -1,12 +1,17 @@
 /* @flow */
 import {
   StyleSheet,
+  Platform
 } from 'react-native'
 
 const IOS_NAV_BAR_HEIGHT = 44
 const IOS_STATUS_BAR_HEIGHT = 20
 const ANDROID_NAV_BAR_HEIGHT = 56
-const ANDROID_STATUS_BAR_HEIGHT = 24
+let ANDROID_STATUS_BAR_HEIGHT = 24
+if (Platform.Version < 21) {
+  ANDROID_STATUS_BAR_HEIGHT = 0
+}
+
 
 export default StyleSheet.create({
   navBarContainer: {},


### PR DESCRIPTION
Due to this change https://github.com/facebook/react-native/pull/6481, no more `SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN` so our custom status view won’t be under the system status any more. The quick fix is just set height of our custom view to `0` on Android Pre-Lollipop
